### PR TITLE
Add missing comma to neovim setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ local hfcc = require('hfcc')
 
 hfcc.setup({
   api_token = "", -- cf Install paragraph
-  model = "bigcode/starcoder" -- can be a model ID or an http(s) endpoint
+  model = "bigcode/starcoder", -- can be a model ID or an http(s) endpoint
   -- parameters that are added to the request body
   query_params = {
     max_new_tokens = 60,


### PR DESCRIPTION
Ran into an error when doing the init.vim plugin setup.

After inspection seems that it was just a missing comma, and adding this to the second makes the example install and load without errors.