### PR TITLE
Fix token read from file

### DIFF
--- a/lua/hfcc/config.lua
+++ b/lua/hfcc/config.lua
@@ -34,7 +34,7 @@ local function get_token()
     if not f then
       api_token = ""
     else
-      api_token = f:read("*a")
+      api_token = string.gsub(f:read("*a"), "[\n\r]", "")
       f:close()
     end
   end


### PR DESCRIPTION
When a token is read from a file, the end-of-line char is also read, unless the file is explicitly saved without it. What happens is that the end-of-line will break the curl query alter one and cause a quite cryptic message about the token not being correct.

This change makes sure any end-of-line or carriage-return character are removed from the token.

Fixes #18