### PR TITLE
Add usage of CursorHoldI instead of CursorMovedI

### DIFF
--- a/lua/hfcc/completion.lua
+++ b/lua/hfcc/completion.lua
@@ -125,6 +125,7 @@ function M.complete()
     api.nvim_win_set_cursor(0, { row_offset, col_offset })
 
     M.suggestion = nil
+    vim.defer_fn(M.schedule, 10)
   end
 end
 
@@ -142,8 +143,9 @@ function M.create_autocmds()
   api.nvim_create_augroup(augroup, { clear = true })
 
   api.nvim_create_autocmd("InsertLeave", { pattern = "*", callback = M.cancel })
+  api.nvim_create_autocmd("CursorMovedI", { pattern = "*", callback = M.cancel })
 
-  api.nvim_create_autocmd("CursorMovedI", {
+  api.nvim_create_autocmd("CursorHoldI", {
     pattern = "*",
     callback = function()
       if M.should_complete() then
@@ -154,6 +156,7 @@ function M.create_autocmds()
       end
     end,
   })
+
 end
 
 function M.setup()


### PR DESCRIPTION
This PR features:
- Reduces amount of request that are being sent to an API. 
- A time after typing a symbol could be controlled and an API would not be bloated with outdated requests.

When I was using my own server I noticed that there are a lot of requests being made when I am still writing a code and not waiting for a suggestion to appear. I sincerely don't think that we need to generate a suggestion as soon as the user hits any symbol. And a request is still happening, server process it.
Vim basically waits certain amount of time until no new keys are pressed by the user and then fires up `CursorHoldI` event.

This autocmd is well documented and further info could be found [here](https://vimdoc.sourceforge.net/htmldoc/autocmd.html#CursorHold)
And time in ms that could be used to control the behaviour is `updatetime`.
By default it is 4000ms.
```vim
set updatetime=500
```