### PR TITLE
Add maximum context windows

### DIFF
--- a/lua/hfcc/completion.lua
+++ b/lua/hfcc/completion.lua
@@ -41,6 +41,25 @@ local function get_context()
   local after_table = api.nvim_buf_get_text(0, fn.line(".") - 1, fn.col("."), fn.line("$") - 1, fn.col("$"), {})
   local after = table.concat(after_table, "\n")
 
+  local before_len = string.len(before)
+  local after_len = string.len(before)
+
+  local before_start = before_len - config.get().max_context_before
+  local after_end = after_len + config.get().max_context_after
+
+  if before_start < 0 then
+      before_start = 0
+  end
+
+  if after_end > after_len then
+      after_end = after_len
+  end
+
+  before = string.sub(before, before_start, before_len)
+  after = string.sub(after, 0, after_end)
+
+
+
   return before, after
 end
 

--- a/lua/hfcc/config.lua
+++ b/lua/hfcc/config.lua
@@ -19,6 +19,8 @@ local default_config = {
   debounce_ms = 80,
   accept_keymap = "<Tab>",
   dismiss_keymap = "<S-Tab>",
+  max_context_after = 5000,
+  max_context_before = 5000
 }
 
 local M = {


### PR DESCRIPTION
This PR adds an ability to control how many characters are being added into the context windows of before and after the cursor.

Sometimes files are way too large, and model's context window is not ready for that; 
Or running an inference on that large chunk of text causes OOM problems.