### PR TITLE
log: Notify only once when api_token is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ require('hfcc').setup({
 local hfcc = require('hfcc')
 
 hfcc.setup({
-  api_token = "", -- cf Install paragraph
+  api_token = nil, -- cf Install paragraph
   model = "bigcode/starcoder", -- can be a model ID or an http(s) endpoint
   -- parameters that are added to the request body
   query_params = {

--- a/lua/hfcc/config.lua
+++ b/lua/hfcc/config.lua
@@ -1,6 +1,6 @@
 ---@class hfcc_config
 local default_config = {
-  api_token = "",
+  api_token = nil,
   model = "bigcode/starcoderbase",
   ---@class hfcc_config_query_params
   query_params = {
@@ -35,7 +35,7 @@ local function get_token()
     local hf_cache_home = os.getenv("HF_HOME") or (default_home .. "/huggingface")
     local f = io.open(hf_cache_home .. "/token", "r")
     if not f then
-      api_token = ""
+      api_token = nil
     else
       api_token = string.gsub(f:read("*a"), "[\n\r]", "")
       f:close()
@@ -52,7 +52,7 @@ function M.setup(opts)
 
   local config = vim.tbl_deep_extend("force", default_config, opts or {})
 
-  if config.api_token == "" then
+  if config.api_token == nil then
     config.api_token = get_token()
   end
 

--- a/lua/hfcc/hf.lua
+++ b/lua/hfcc/hf.lua
@@ -63,19 +63,21 @@ local function create_curl_options()
   return curl_options
 end
 
-M.fetch_suggestion = function(request, callback)
+local function get_authorization_header()
   local api_token = config.get().api_token
-  if api_token == "" then
-    vim.notify("[HFcc] api token is empty, suggestion might not work", vim.log.levels.WARN)
+  if api_token == nil then
+    return ""
+  else
+    return '-H "Authorization: Bearer ' .. api_token .. '" '
   end
+end
+
+M.fetch_suggestion = function(request, callback)
   local query = 'curl "'
     .. get_url()
-    .. '" \z
-      -H "Content-type: application/json" \z
-      -H "Authorization: Bearer '
-    .. api_token
-    .. '" \z
-      -d@'
+    .. '" -H "Content-type: application/json" '
+    .. get_authorization_header()
+    .. "-d@"
     .. os.getenv("HOME")
     .. "/.tmp_hfcc_inputs.json"
     .. create_curl_options()

--- a/lua/hfcc/init.lua
+++ b/lua/hfcc/init.lua
@@ -23,6 +23,11 @@ M.setup = function(opts)
 
   config.setup(opts)
 
+  local api_token = config.get().api_token
+  if api_token == nil then
+    vim.notify("[HFcc] api token is empty, suggestion might not work", vim.log.levels.DEBUG)
+  end
+
   completion.setup()
   completion.create_autocmds()
 


### PR DESCRIPTION
`fetch_suggestion` is called for each API call. This function warns about empty `api_token` each time. This notification spams the UX when autentication is not needed. As such we can move it in the `init` to have the notification once.