### PR TITLE
fix: `config.debounce_ms` -> `config.get().debounce_ms`

### DIFF
--- a/lua/hfcc/completion.lua
+++ b/lua/hfcc/completion.lua
@@ -87,7 +87,7 @@ end
 function M.schedule()
   M.cancel()
 
-  M.timer = fn.timer_start(config.debounce_ms, function()
+  M.timer = fn.timer_start(config.get().debounce_ms, function()
     if fn.mode() == "i" then
       M.suggest()
     end

--- a/lua/hfcc/config.lua
+++ b/lua/hfcc/config.lua
@@ -16,7 +16,7 @@ local default_config = {
     middle = "<fim_middle>",
     suffix = "<fim_suffix>",
   },
-  debounce_ms = 80,
+  debounce_ms = 150,
   accept_keymap = "<Tab>",
   dismiss_keymap = "<S-Tab>",
   max_context_after = 5000,


### PR DESCRIPTION
`debounce_ms` parameter was ignored because it was incorrectly fetched from the config.

Also increased the default value from 80ms to 150ms to avoid sending too many requests on slower typing.